### PR TITLE
Capture a block of verbal expressions

### DIFF
--- a/lib/verbal_expressions.rb
+++ b/lib/verbal_expressions.rb
@@ -127,7 +127,11 @@ class VerEx < Regexp
     add(")")
   end
 
-
+  def capture(name = nil, &block)
+    begin_capture(name)
+    yield
+    end_capture
+  end
 
   private
 

--- a/spec/verbal_expressions_spec.rb
+++ b/spec/verbal_expressions_spec.rb
@@ -19,6 +19,20 @@ describe VerEx do
         matcher.match('Jerry scored 5 goals!')['goals'].should == '5'
       end
 
+      context 'with a block' do
+
+        let(:matcher) do
+          VerEx.new do
+            start_of_line
+            capture('goals') { word }
+          end
+        end
+
+        it 'Successfully captures player by index' do
+          matcher.match('Jerry scored 5 goals!')['goals'].should == 'Jerry'
+        end
+      end
+
     end
 
     describe 'without name' do
@@ -36,6 +50,18 @@ describe VerEx do
         matcher.match('Jerry scored 5 goals!')[1].should == 'Jerry'
       end
 
+      context 'with a block' do
+        let(:matcher) do
+          VerEx.new do
+            start_of_line
+            capture { word }
+          end
+        end
+
+        it 'Successfully captures player by index' do
+          matcher.match('Jerry scored 5 goals!')[1].should == 'Jerry'
+        end
+      end
     end
 
   end


### PR DESCRIPTION
In addition to using `begin_capture` and `end_capture` this adds a `capture {}` method to perform both for you.
