### PR TITLE
Fixed issue #4, added min,max arguments for multiple()

### DIFF
--- a/lib/verbal_expressions.rb
+++ b/lib/verbal_expressions.rb
@@ -15,6 +15,17 @@ class VerEx < Regexp
     super(@prefixes + @source + @suffixes, @modifiers)
   end
 
+  def initialize(chain = true)
+    if chain == true
+      @prefixes = ""
+      @source   = ""
+      @suffixes = ""
+
+      @chain = true
+      super("")
+    end
+  end
+
   def method_missing(method, *args, &block)
     @self_before_instance_eval.send method, *args, &block
   end
@@ -28,33 +39,45 @@ class VerEx < Regexp
   def find(value)
     value = sanitize(value)
     add("(?:#{value})")
+
+    if @chain == true ;return self;end
   end
 
   # start or end of line
 
   def start_of_line(enable = true)
     @prefixes = '^' if enable
+
+    if @chain == true ;return self;end
   end
 
   def end_of_line(enable = true)
     @suffixes = '$' if enable
+
+    if @chain == true ;return self;end
   end
 
   # Maybe is used to add values with ?
   def maybe(value)
     value = sanitize(value)
     add("(?:#{value})?")
+
+    if @chain == true ;return self;end
   end
 
   # Any character any number of times
   def anything
     add("(?:.*)")
+
+    if @chain == true ;return self;end
   end
 
   # Anything but these characters
   def anything_but(value)
     value = sanitize(value)
     add("(?:[^#{value}]*)")
+
+    if @chain == true ;return self;end
   end
 
   # Regular expression special chars
@@ -62,6 +85,8 @@ class VerEx < Regexp
 
   def line_break
     add('(?:\n|(?:\r\n))')
+
+    if @chain == true ;return self;end
   end
 
   # And a shorthand for html-minded
@@ -69,45 +94,57 @@ class VerEx < Regexp
 
   def tab
     add('\t')
+
+    if @chain == true ;return self;end
   end
 
   # Any alphanumeric
   def word
     add('\w+')
+
+    if @chain == true ;return self;end
   end
 
   # Any single digit
   def digit
-	add('\d')
+  add('\d')
+
+  if @chain == true ;return self;end
   end
 
   # Any integer (multiple digits)
   def integer
     one_or_more { digit }
+
+    if @chain == true ;return self;end
   end
 
   # Any whitespace character
   def whitespace()
     add('\s+')
+
+    if @chain == true ;return self;end
   end
 
   # Any given character
   def any_of(value)
     value = sanitize(value)
     add("[#{value}]")
+
+    if @chain == true ;return self;end
   end
 
   #At least one of some other thing
   def one_or_more(&b)
-	add("(?:")
-	yield
-	add(")+")
+  add("(?:")
+  yield
+  add(")+")
   end
 
   def zero_or_more(&b)
-	add("(?:")
-	yield
-	add(")*")
+  add("(?:")
+  yield
+  add(")*")
   end
 
   alias_method :any, :any_of
@@ -122,6 +159,8 @@ class VerEx < Regexp
     end
     value += "]"
     add(value)
+
+    if @chain == true ;return self;end
   end
 
   # Loops
@@ -130,6 +169,8 @@ class VerEx < Regexp
     value = sanitize(value)
     value += "+"
     add(value)
+
+    if @chain == true ;return self;end
   end
 
   # Adds alternative expressions
@@ -148,16 +189,24 @@ class VerEx < Regexp
     else
       add("(")
     end
+
+    if @chain == true ;return self;end
   end
 
   def end_capture
     add(")")
+
+    if @chain == true ;return self;end
   end
 
   def capture(name = nil, &block)
     begin_capture(name)
     yield
     end_capture
+  end
+
+  def end_expression
+    return Regexp.new(@prefixes + @source + @suffixes)
   end
 
   private

--- a/lib/verbal_expressions.rb
+++ b/lib/verbal_expressions.rb
@@ -15,17 +15,6 @@ class VerEx < Regexp
     super(@prefixes + @source + @suffixes, @modifiers)
   end
 
-  def initialize(chain = true)
-    if chain == true
-      @prefixes = ""
-      @source   = ""
-      @suffixes = ""
-
-      @chain = true
-      super("")
-    end
-  end
-
   def method_missing(method, *args, &block)
     @self_before_instance_eval.send method, *args, &block
   end
@@ -40,7 +29,7 @@ class VerEx < Regexp
     value = sanitize(value)
     add("(?:#{value})")
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # start or end of line
@@ -48,13 +37,13 @@ class VerEx < Regexp
   def start_of_line(enable = true)
     @prefixes = '^' if enable
 
-    if @chain == true ;return self;end
+    return self
   end
 
   def end_of_line(enable = true)
     @suffixes = '$' if enable
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Maybe is used to add values with ?
@@ -62,14 +51,14 @@ class VerEx < Regexp
     value = sanitize(value)
     add("(?:#{value})?")
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Any character any number of times
   def anything
     add("(?:.*)")
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Anything but these characters
@@ -77,7 +66,7 @@ class VerEx < Regexp
     value = sanitize(value)
     add("(?:[^#{value}]*)")
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Regular expression special chars
@@ -86,7 +75,7 @@ class VerEx < Regexp
   def line_break
     add('(?:\n|(?:\r\n))')
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # And a shorthand for html-minded
@@ -95,35 +84,35 @@ class VerEx < Regexp
   def tab
     add('\t')
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Any alphanumeric
   def word
     add('\w+')
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Any single digit
   def digit
-  add('\d')
+    add('\d')
 
-  if @chain == true ;return self;end
+    return self
   end
 
   # Any integer (multiple digits)
   def integer
     one_or_more { digit }
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Any whitespace character
   def whitespace()
     add('\s+')
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Any given character
@@ -131,20 +120,20 @@ class VerEx < Regexp
     value = sanitize(value)
     add("[#{value}]")
 
-    if @chain == true ;return self;end
+    return self
   end
 
   #At least one of some other thing
   def one_or_more(&b)
-  add("(?:")
-  yield
-  add(")+")
+    add("(?:")
+    yield
+    add(")+")
   end
 
   def zero_or_more(&b)
-  add("(?:")
-  yield
-  add(")*")
+    add("(?:")
+    yield
+    add(")*")
   end
 
   alias_method :any, :any_of
@@ -160,7 +149,7 @@ class VerEx < Regexp
     value += "]"
     add(value)
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Loops
@@ -170,7 +159,7 @@ class VerEx < Regexp
     value += "+"
     add(value)
 
-    if @chain == true ;return self;end
+    return self
   end
 
   # Adds alternative expressions
@@ -190,23 +179,19 @@ class VerEx < Regexp
       add("(")
     end
 
-    if @chain == true ;return self;end
+    return self
   end
 
   def end_capture
     add(")")
 
-    if @chain == true ;return self;end
+    return self
   end
 
   def capture(name = nil, &block)
     begin_capture(name)
     yield
     end_capture
-  end
-
-  def end_expression
-    return Regexp.new(@prefixes + @source + @suffixes)
   end
 
   private
@@ -231,3 +216,19 @@ class VerEx < Regexp
     end
 
 end
+
+class VerExChain < VerEx
+  def initialize
+    @prefixes  = ""
+    @source    = ""
+    @suffixes  = ""
+    @modifiers = "" 
+  end
+
+  def end
+    return Regexp.new(@prefixes + @source + @suffixes)
+  end
+end
+
+# Usage of VerExChain
+# 

--- a/lib/verbal_expressions.rb
+++ b/lib/verbal_expressions.rb
@@ -154,9 +154,15 @@ class VerEx < Regexp
 
   # Loops
 
-  def multiple(value)
-    value = sanitize(value)
-    value += "+"
+  def multiple(value,min=nil,max=nil)
+    value = "(" + sanitize(value) + ")"
+    if min != nil and max != nil 
+      value += "{#{min},#{max}}"
+    elsif min != nil and max == nil
+      value += "{#{min},}"
+    else
+      value += "+"
+    end
     add(value)
 
     return self
@@ -281,3 +287,13 @@ end
 # result = replace_me.gsub( expression, "duck" );
 
 # puts result # Outputs "Replace duck with a duck"
+
+
+# multiple() tests - 
+# v = VerEx.new do
+#    start_of_line
+#    multiple("1",2,5)
+#    end_of_line
+#  end
+# puts "Match" if v =~ "11111"
+# puts v.source

--- a/spec/verbal_expressions_spec.rb
+++ b/spec/verbal_expressions_spec.rb
@@ -164,6 +164,47 @@ describe VerEx do
 
       matcher.match('+++++')['mult'].should == '+++++'
     end
+
+    it 'does not match string with less than/equal to min occurrence of value ' do
+      matcher = VerEx.new do
+        start_of_line
+        multiple("1",5)
+        end_of_line
+      end
+
+      matcher.match("1").should be_false
+    end
+
+    it 'matches string with occurence greater than equal to min' do
+      matcher = VerEx.new do
+        start_of_line
+        multiple("1",2)
+        end_of_line
+      end
+
+      matcher.match("111").should be_true
+    end
+
+    it 'matches string with occurence greater than equal to min and less than equal to max' do
+      matcher = VerEx.new do
+        start_of_line
+        multiple("1",2,5)
+        end_of_line
+      end
+
+      matcher.match("111").should be_true
+    end
+
+    it 'does not match with occurence greater than max' do
+      matcher = VerEx.new do
+        start_of_line
+        multiple("1",2,5)
+        end_of_line
+      end
+
+      matcher.match("111111").should be_false
+    end
+
   end
 
   describe '#line_break' do

--- a/spec/verbal_expressions_spec.rb
+++ b/spec/verbal_expressions_spec.rb
@@ -311,3 +311,115 @@ describe VerEx do
     end
   end
 end
+
+
+describe VerExChain do
+
+  describe '#or' do
+    describe 'matches a link' do
+      let(:matcher) do
+        VerExChain.new
+          .find('http://')
+          .or
+          .find('ftp://')
+          .end
+      end
+
+      it 'matches ftp://' do
+        matcher.match('ftp://ftp.google.com/').should be_true
+      end
+
+      it 'matches http://' do
+        matcher.match('http://www.google.com').should be_true
+      end
+    end
+  end
+
+  describe '#find' do
+
+    let(:matcher) do
+      VerExChain.new
+        .find('lions')
+        .end
+    end
+
+    it 'should correctly build find regex' do
+      matcher.source.should == '(?:lions)'
+    end
+
+    it 'should correctly match find' do
+      matcher.match('lions').should be_true
+    end
+
+    it 'should match part of a string with find' do
+      matcher.match('lions, tigers, and bears, oh my!').should be_true
+    end
+
+    it 'should only match the `find` part of a string' do
+      matcher.match('lions, tigers, and bears, oh my!')[0].should == 'lions'
+    end
+  end
+
+  describe 'URL Regex Test' do
+    let(:matcher) do
+      VerExChain.new
+        .start_of_line
+        .find('http')
+        .maybe('s')
+        .then('://')
+        .maybe('www.')
+        .anything_but(' ')
+        .end_of_line
+    end
+
+    it 'matches https://google.com' do
+      matcher.match("https://google.com").should be_true
+    end
+
+    it 'does not match htp://' do
+      matcher.match("htp://google.com").should be_false
+    end
+
+    it 'successfully builds regex for matching URLs' do
+      matcher.source.should == '^(?:http)(?:s)?(?:://)(?:www\\.)?(?:[^\\ ]*)$'
+    end
+
+    it 'matches https URL' do
+      matcher.match('https://google.com').should be_true
+    end
+
+    it 'matches a URL with www' do
+      matcher.match('https://www.google.com').should be_true
+    end
+
+    it 'fails to match when URL has a space' do
+      matcher.match('http://goo gle.com').should be_false
+    end
+  end
+
+  describe '#find' do
+
+    let(:matcher) do
+      VerExChain.new
+        .find('lions') 
+        .end
+    end
+
+    it 'should correctly build find regex' do
+      matcher.source.should == '(?:lions)'
+    end
+
+    it 'should correctly match find' do
+      matcher.match('lions').should be_true
+    end
+
+    it 'should match part of a string with find' do
+      matcher.match('lions, tigers, and bears, oh my!').should be_true
+    end
+
+    it 'should only match the `find` part of a string' do
+      matcher.match('lions, tigers, and bears, oh my!')[0].should == 'lions'
+    end
+  end
+
+end


### PR DESCRIPTION
Added a new class calle VerExChain. VerExChain needs to end with a call to .end or .end_of_line(). All tests pass.  
The multiple() method now accepts an argument min and max to match occurrences between desired limits. Tests for this have also been added.
